### PR TITLE
feat(): add feature based on parity pr

### DIFF
--- a/Storage/Header.cs
+++ b/Storage/Header.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Supabase.Storage;
+
+/// <summary>
+///     Represents a container for HTTP headers, providing functionality for adding and retrieving headers.
+/// </summary>
+public class Header
+{
+    private readonly Dictionary<string, string> _headers = [];
+
+    /// <summary>
+    ///     Adds a new header to the collection or updates the value of an existing header.
+    ///     Key will be lowercased
+    /// </summary>
+    /// <param name="key">The key of the header to add or update.</param>
+    /// <param name="value">The value associated with the header key.</param>
+    public void Add(string key, string value)
+    {
+        var newKey = key.ToLower();
+        foreach (var header in _headers.Where(header => header.Key.ToLower() == newKey))
+            _headers.Remove(header.Key);
+
+        _headers.Add(newKey, value);
+    }
+
+    /// <summary>
+    ///     Adds multiple headers to the collection or updates the values of existing headers.
+    ///     Key will be lowercased
+    /// </summary>
+    /// <param name="headers">
+    ///     A dictionary containing the headers to add or update, where the key is the header name and the
+    ///     value is the header value.
+    /// </param>
+    public void Add(Dictionary<string, string> headers)
+    {
+        foreach (var header in headers)
+            Add(header.Key, header.Value);
+    }
+
+    /// <summary>
+    ///     Retrieves all the headers in the collection.
+    /// </summary>
+    /// <returns>A dictionary containing all headers, where the key is the header name and the value is the header value.</returns>
+    public Dictionary<string, string> Get()
+    {
+        return _headers;
+    }
+}

--- a/Storage/SortBy.cs
+++ b/Storage/SortBy.cs
@@ -5,9 +5,9 @@ namespace Supabase.Storage
     public class SortBy
     {
         [JsonProperty("column")]
-        public string? Column { get; set; }
+        public string? Column { get; set; } = "name";
 
         [JsonProperty("order")]
-        public string? Order { get; set; }
+        public string? Order { get; set; } = "asc";
     }
 }

--- a/Storage/StorageFileApi.cs
+++ b/Storage/StorageFileApi.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -24,6 +23,8 @@ namespace Supabase.Storage
         protected Dictionary<string, string> Headers { get; set; }
         protected string? BucketId { get; set; }
 
+        protected Header StorageHeader = new();
+
         public StorageFileApi(
             string url,
             string bucketId,
@@ -45,6 +46,7 @@ namespace Supabase.Storage
             BucketId = bucketId;
             Options ??= new ClientOptions();
             Headers = headers ?? new Dictionary<string, string>();
+            StorageHeader.Add(Headers);
         }
 
         /// <summary>
@@ -289,15 +291,12 @@ namespace Supabase.Storage
             if (inferContentType)
                 options.ContentType = MimeMapping.MimeUtility.GetMimeMapping(localFilePath);
 
-            var headers = new Dictionary<string, string>(Headers)
-            {
-                ["Authorization"] = $"Bearer {signedUrl.Token}",
-                ["cache-control"] = $"max-age={options.CacheControl}",
-                ["content-type"] = options.ContentType,
-            };
+            StorageHeader.Add("Authorization", $"Bearer {signedUrl.Token}");
+            StorageHeader.Add("cache-control", $"max-age={options.CacheControl}");
+            StorageHeader.Add("content-type", options.ContentType);
 
             if (options.Upsert)
-                headers.Add("x-upsert", options.Upsert.ToString().ToLower());
+                StorageHeader.Add("x-upsert", options.Upsert.ToString().ToLower());
 
             var progress = new Progress<float>();
 
@@ -307,7 +306,7 @@ namespace Supabase.Storage
             await Helpers.HttpUploadClient!.UploadFileAsync(
                 signedUrl.SignedUrl,
                 localFilePath,
-                headers,
+                StorageHeader.Get(),
                 progress
             );
 
@@ -336,16 +335,16 @@ namespace Supabase.Storage
             if (inferContentType)
                 options.ContentType = MimeMapping.MimeUtility.GetMimeMapping(signedUrl.Key);
 
-            var headers = new Dictionary<string, string>(Headers)
-            {
-                ["Authorization"] = $"Bearer {signedUrl.Token}",
-                ["cache-control"] = $"max-age={options.CacheControl}",
-                ["content-type"] = options.ContentType,
-            };
+            StorageHeader.Add("Authorization", $"Bearer {signedUrl.Token}");
+            StorageHeader.Add("cache-control", $"max-age={options.CacheControl}");
+            StorageHeader.Add("content-type", options.ContentType);
 
             if (options.Upsert)
-                headers.Add("x-upsert", options.Upsert.ToString().ToLower());
+                StorageHeader.Add("x-upsert", options.Upsert.ToString().ToLower());
 
+            if (options.Metadata != null)
+                 StorageHeader.Add("x-metadata", ParseMetadata(options.Metadata));
+                
             var progress = new Progress<float>();
 
             if (onProgress != null)
@@ -354,7 +353,7 @@ namespace Supabase.Storage
             await Helpers.HttpUploadClient!.UploadBytesAsync(
                 signedUrl.SignedUrl,
                 data,
-                headers,
+                StorageHeader.Get(),
                 progress
             );
 
@@ -676,29 +675,26 @@ namespace Supabase.Storage
         {
             Uri uri = new Uri($"{Url}/object/{GetFinalPath(supabasePath)}");
 
-            var headers = new Dictionary<string, string>(Headers)
-            {
-                { "cache-control", $"max-age={options.CacheControl}" },
-                { "content-type", options.ContentType },
-            };
+            StorageHeader.Add("cache-control", $"max-age={options.CacheControl}");
+            StorageHeader.Add("content-type", options.ContentType);
 
             if (options.Upsert)
-                headers.Add("x-upsert", options.Upsert.ToString().ToLower());
+                StorageHeader.Add("x-upsert", options.Upsert.ToString().ToLower());
 
             if (options.Metadata != null)
-                headers.Add("x-metadata", ParseMetadata(options.Metadata));
+                StorageHeader.Add("x-metadata", ParseMetadata(options.Metadata));
 
-            options.Headers?.ToList().ForEach(x => headers.Add(x.Key, x.Value));
+            options.Headers?.ToList().ForEach(x => StorageHeader.Add(x.Key, x.Value));
 
             if (options.Duplex != null)
-                headers.Add("x-duplex", options.Duplex.ToLower());
+                StorageHeader.Add("x-duplex", options.Duplex.ToLower());
 
             var progress = new Progress<float>();
 
             if (onProgress != null)
                 progress.ProgressChanged += onProgress;
 
-            await Helpers.HttpUploadClient!.UploadFileAsync(uri, localPath, headers, progress, cancellationToken);
+            await Helpers.HttpUploadClient!.UploadFileAsync(uri, localPath, StorageHeader.Get(), progress, cancellationToken);
 
             return GetFinalPath(supabasePath);
         }
@@ -712,11 +708,8 @@ namespace Supabase.Storage
         )
         {
             var uri = new Uri($"{Url}/upload/resumable");
-
-            var headers = new Dictionary<string, string>(Headers)
-            {
-                { "cache-control", $"max-age={options.CacheControl}" },
-            };
+            
+            StorageHeader.Add("cache-control", $"max-age={options.CacheControl}");
 
             var metadata = new MetadataCollection
             {
@@ -726,15 +719,15 @@ namespace Supabase.Storage
             };
 
             if (options.Upsert)
-                headers.Add("x-upsert", options.Upsert.ToString().ToLower());
+                StorageHeader.Add("x-upsert", options.Upsert.ToString().ToLower());
 
             if (options.Metadata != null)
-                headers.Add("x-metadata", ParseMetadata(options.Metadata));
+                StorageHeader.Add("x-metadata", ParseMetadata(options.Metadata));
 
-            options.Headers?.ToList().ForEach(x => headers.Add(x.Key, x.Value));
+            options.Headers?.ToList().ForEach(x => StorageHeader.Add(x.Key, x.Value));
 
             if (options.Duplex != null)
-                headers.Add("x-duplex", options.Duplex.ToLower());
+                StorageHeader.Add("x-duplex", options.Duplex.ToLower());
 
             var progress = new Progress<float>();
 
@@ -745,7 +738,7 @@ namespace Supabase.Storage
                 uri,
                 localPath,
                 metadata,
-                headers,
+                StorageHeader.Get(),
                 progress,
                 cancellationToken
             );
@@ -761,10 +754,7 @@ namespace Supabase.Storage
         {
             var uri = new Uri($"{Url}/upload/resumable");
 
-            var headers = new Dictionary<string, string>(Headers)
-            {
-                { "cache-control", $"max-age={options.CacheControl}" },
-            };
+            StorageHeader.Add("cache-control", $"max-age={options.CacheControl}");
 
             var metadata = new MetadataCollection
             {
@@ -774,15 +764,15 @@ namespace Supabase.Storage
             };
 
             if (options.Upsert)
-                headers.Add("x-upsert", options.Upsert.ToString().ToLower());
+                StorageHeader.Add("x-upsert", options.Upsert.ToString().ToLower());
 
             if (options.Metadata != null)
                 metadata["metadata"] = JsonConvert.SerializeObject(options.Metadata);
 
-            options.Headers?.ToList().ForEach(x => headers.Add(x.Key, x.Value));
+            options.Headers?.ToList().ForEach(x => StorageHeader.Add(x.Key, x.Value));
 
             if (options.Duplex != null)
-                headers.Add("x-duplex", options.Duplex.ToLower());
+                StorageHeader.Add("x-duplex", options.Duplex.ToLower());
 
             var progress = new Progress<float>();
 
@@ -793,7 +783,7 @@ namespace Supabase.Storage
                 uri,
                 data,
                 metadata,
-                headers,
+                StorageHeader.Get(),
                 progress,
                 cancellationToken
             );
@@ -816,30 +806,27 @@ namespace Supabase.Storage
         )
         {
             Uri uri = new Uri($"{Url}/object/{GetFinalPath(supabasePath)}");
-
-            var headers = new Dictionary<string, string>(Headers)
-            {
-                { "cache-control", $"max-age={options.CacheControl}" },
-                { "content-type", options.ContentType },
-            };
-
+            
+            StorageHeader.Add("cache-control", $"max-age={options.CacheControl}");
+            StorageHeader.Add("content-type", options.ContentType);
+            
             if (options.Upsert)
-                headers.Add("x-upsert", options.Upsert.ToString().ToLower());
+                StorageHeader.Add("x-upsert", options.Upsert.ToString().ToLower());
 
             if (options.Metadata != null)
-                headers.Add("x-metadata", ParseMetadata(options.Metadata));
+                StorageHeader.Add("x-metadata", ParseMetadata(options.Metadata));
 
-            options.Headers?.ToList().ForEach(x => headers.Add(x.Key, x.Value));
+            options.Headers?.ToList().ForEach(x => StorageHeader.Add(x.Key, x.Value));
 
             if (options.Duplex != null)
-                headers.Add("x-duplex", options.Duplex.ToLower());
+                StorageHeader.Add("x-duplex", options.Duplex.ToLower());
 
             var progress = new Progress<float>();
 
             if (onProgress != null)
                 progress.ProgressChanged += onProgress;
 
-            await Helpers.HttpUploadClient!.UploadBytesAsync(uri, data, headers, progress, cancellationToken);
+            await Helpers.HttpUploadClient!.UploadBytesAsync(uri, data, StorageHeader.Get(), progress, cancellationToken);
 
             return GetFinalPath(supabasePath);
         }

--- a/StorageTests/HeaderTests.cs
+++ b/StorageTests/HeaderTests.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Supabase.Storage;
+
+namespace StorageTests;
+
+[TestClass]
+public class HeaderTests
+{
+    [TestMethod("Header: Add Single Header")]
+    public void TestHeaderAddSingle()
+    {
+        var header = new Header();
+        header.Add("Content-Type", "application/json");
+
+        var headers = header.Get();
+        Assert.AreEqual(1, headers.Count);
+        Assert.IsTrue(headers.ContainsKey("content-type"));
+        Assert.AreEqual("application/json", headers["content-type"]);
+    }
+
+    [TestMethod("Header: Add Multiple Headers")]
+    public void TestHeaderAddMultiple()
+    {
+        var header = new Header();
+        var dictionary = new Dictionary<string, string>
+        {
+            { "Content-Type", "application/json" },
+            { "X-Custom-Header", "Value" },
+        };
+
+        header.Add(dictionary);
+
+        var headers = header.Get();
+        Assert.AreEqual(2, headers.Count);
+        Assert.IsTrue(headers.ContainsKey("content-type"));
+        Assert.IsTrue(headers.ContainsKey("x-custom-header"));
+        Assert.AreEqual("application/json", headers["content-type"]);
+        Assert.AreEqual("Value", headers["x-custom-header"]);
+    }
+
+    [TestMethod("Header: Update Existing Header")]
+    public void TestHeaderUpdateExisting()
+    {
+        var header = new Header();
+        header.Add("Content-Type", "application/json");
+        header.Add("CONTENT-TYPE", "text/plain");
+
+        var headers = header.Get();
+        Assert.AreEqual(1, headers.Count);
+        Assert.IsTrue(headers.ContainsKey("content-type"));
+        Assert.AreEqual("text/plain", headers["content-type"]);
+    }
+
+    [TestMethod("Header: Update Existing Header with Different Case")]
+    public void TestHeaderUpdateExistingDifferentCase()
+    {
+        var header = new Header();
+        header.Add("X-Custom", "value1");
+        header.Add("x-custom", "value2");
+
+        var headers = header.Get();
+        Assert.AreEqual(1, headers.Count);
+        Assert.AreEqual("value2", headers["x-custom"]);
+    }
+}

--- a/StorageTests/SearchOptionsTests.cs
+++ b/StorageTests/SearchOptionsTests.cs
@@ -1,0 +1,30 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Supabase.Storage;
+
+namespace StorageTests;
+
+[TestClass]
+public class SearchOptionsTests
+{
+    [TestMethod("SearchOptions: Test Default Sort Values")]
+    public void TestDefaultSortValues()
+    {
+        var options = new SearchOptions();
+        
+        Assert.AreEqual(options.SortBy.Column, "name");
+        Assert.AreEqual(options.SortBy.Order, "asc");
+    }
+    
+    
+    [TestMethod("SearchOptions: Test Default Sort Column Value")]
+    public void TestDefaultSortColumnValue()
+    {
+        var options = new SearchOptions()
+        {
+           
+        };
+        
+        Assert.AreEqual(options.SortBy.Column, "name");
+        Assert.AreEqual(options.SortBy.Order, "asc");
+    }
+}

--- a/StorageTests/SortByTests.cs
+++ b/StorageTests/SortByTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Supabase.Storage;
+
+namespace StorageTests;
+
+[TestClass]
+public class SortByTests
+{
+    [TestMethod("SortBy: Test Default Sort Values")]
+    public void TestDefaultSortValues()
+    {
+        var options = new SortBy();
+        
+        Assert.AreEqual(options.Column, "name");
+        Assert.AreEqual(options.Order, "asc");
+    }
+    
+    
+    [TestMethod("SortBy: Test Default Sort Column Value")]
+    public void TestDefaultSortColumnValue()
+    {
+        var options = new SortBy()
+        {
+           Column = "status"
+        };
+        
+        Assert.AreEqual(options.Column, "status");
+        Assert.AreEqual(options.Order, "asc");
+    }
+    
+    [TestMethod("SortBy: Test Default Sort Order Value")]
+    public void TestDefaultSortOrderValue()
+    {
+        var options = new SortBy()
+        {
+            Order = "desc"
+        };
+        
+        Assert.AreEqual(options.Column, "name");
+        Assert.AreEqual(options.Order, "desc");
+    }
+    
+    [TestMethod("SortBy: Test SortBy")]
+    public void TestSortByValue()
+    {
+        var options = new SortBy()
+        {
+            Order = "desc",
+            Column = "updated_at"
+        };
+        
+        Assert.AreEqual(options.Column, "updated_at");
+        Assert.AreEqual(options.Order, "desc");
+    }
+}

--- a/StorageTests/StorageFileTests.cs
+++ b/StorageTests/StorageFileTests.cs
@@ -664,5 +664,182 @@ public class StorageFileTests
         var result = await _bucket.CreateUploadSignedUrl("test.png");
         Assert.IsTrue(Uri.IsWellFormedUriString(result.SignedUrl.ToString(), UriKind.Absolute));
     }
+    
+    [TestMethod("File: Test List Default Values")]
+    public async Task GetListDefaultValues()
+    {
+        var tsc = new TaskCompletionSource<bool>();
+
+        var name1 = $"1-{Guid.NewGuid()}.bin";
+        var name2 = $"2-{Guid.NewGuid()}.bin";
+        var name3 = $"3-{Guid.NewGuid()}.bin";
+
+        await _bucket.Upload(
+            new Byte[] { 0x0, 0x0, 0x0 },
+            name1,
+            null,
+            (_, _) => tsc.TrySetResult(true)
+        );
+        
+        await _bucket.Upload(
+            new Byte[] { 0x0, 0x0, 0x0 },
+            name2,
+            null,
+            (_, _) => tsc.TrySetResult(true)
+        );
+        
+        await _bucket.Upload(
+            new Byte[] { 0x0, 0x0, 0x0 },
+            name3,
+            null,
+            (_, _) => tsc.TrySetResult(true)
+        );
+        
+        var list = await _bucket.List();
+        Assert.IsNotNull(list);
+        Assert.AreEqual(3, list.Count);
+        Assert.AreEqual(name1, list[0].Name);
+        Assert.AreEqual(name2, list[1].Name);
+        Assert.AreEqual(name3, list[2].Name);
+    }
+    
+    [TestMethod("File: Test List Ordered Values")]
+    public async Task GetListOrderedValues()
+    {
+        var tsc = new TaskCompletionSource<bool>();
+
+        var name1 = $"1-{Guid.NewGuid()}.bin";
+        var name2 = $"2-{Guid.NewGuid()}.bin";
+        var name3 = $"3-{Guid.NewGuid()}.bin";
+
+        await _bucket.Upload(
+            new Byte[] { 0x0, 0x0, 0x0 },
+            name1,
+            null,
+            (_, _) => tsc.TrySetResult(true)
+        );
+        
+        await _bucket.Upload(
+            new Byte[] { 0x0, 0x0, 0x0 },
+            name2,
+            null,
+            (_, _) => tsc.TrySetResult(true)
+        );
+        
+        await _bucket.Upload(
+            new Byte[] { 0x0, 0x0, 0x0 },
+            name3,
+            null,
+            (_, _) => tsc.TrySetResult(true)
+        );
+        var sortBy = new SortBy()
+        {
+            Order = "desc"
+        };
+        var options = new SearchOptions
+        {
+            SortBy = sortBy
+        };
+        
+        var list = await _bucket.List("", options);
+        Assert.IsNotNull(list);
+        Assert.AreEqual(3, list.Count);
+        Assert.AreEqual(name3, list[0].Name);
+        Assert.AreEqual(name2, list[1].Name);
+        Assert.AreEqual(name1, list[2].Name);
+    }
+    
+    [TestMethod("File: Test List Column Values")]
+    public async Task GetListColumnValues()
+    {
+        var tsc = new TaskCompletionSource<bool>();
+
+        var name1 = $"1-{Guid.NewGuid()}.bin";
+        var name2 = $"2-{Guid.NewGuid()}.bin";
+        var name3 = $"3-{Guid.NewGuid()}.bin";
+
+        await _bucket.Upload(
+            new Byte[] { 0x0, 0x0, 0x0 },
+            name1,
+            null,
+            (_, _) => tsc.TrySetResult(true)
+        );
+        
+        await _bucket.Upload(
+            new Byte[] { 0x0, 0x0, 0x0 },
+            name2,
+            null,
+            (_, _) => tsc.TrySetResult(true)
+        );
+        
+        await _bucket.Upload(
+            new Byte[] { 0x0, 0x0, 0x0 },
+            name3,
+            null,
+            (_, _) => tsc.TrySetResult(true)
+        );
+        var sortBy = new SortBy()
+        {
+            Column = "created_at",
+        };
+        var options = new SearchOptions
+        {
+            SortBy = sortBy
+        };
+        
+        var list = await _bucket.List("", options);
+        Assert.IsNotNull(list);
+        Assert.AreEqual(3, list.Count);
+        Assert.AreEqual(name1, list[0].Name);
+        Assert.AreEqual(name2, list[1].Name);
+        Assert.AreEqual(name3, list[2].Name);
+    }
+    
+    [TestMethod("File: Test List Override Sort Values")]
+    public async Task GetListOverrideSortValues()
+    {
+        var tsc = new TaskCompletionSource<bool>();
+
+        var name1 = $"1-{Guid.NewGuid()}.bin";
+        var name2 = $"2-{Guid.NewGuid()}.bin";
+        var name3 = $"3-{Guid.NewGuid()}.bin";
+
+        await _bucket.Upload(
+            new Byte[] { 0x0, 0x0, 0x0 },
+            name1,
+            null,
+            (_, _) => tsc.TrySetResult(true)
+        );
+        
+        await _bucket.Upload(
+            new Byte[] { 0x0, 0x0, 0x0 },
+            name2,
+            null,
+            (_, _) => tsc.TrySetResult(true)
+        );
+        
+        await _bucket.Upload(
+            new Byte[] { 0x0, 0x0, 0x0 },
+            name3,
+            null,
+            (_, _) => tsc.TrySetResult(true)
+        );
+        var sortBy = new SortBy()
+        {
+            Column = "created_at",
+            Order = "desc"
+        };
+        var options = new SearchOptions
+        {
+            SortBy = sortBy
+        };
+        
+        var list = await _bucket.List("", options);
+        Assert.IsNotNull(list);
+        Assert.AreEqual(3, list.Count);
+        Assert.AreEqual(name3, list[0].Name);
+        Assert.AreEqual(name2, list[1].Name);
+        Assert.AreEqual(name1, list[2].Name);
+    }
 }
 

--- a/StorageTests/StorageTests.csproj
+++ b/StorageTests/StorageTests.csproj
@@ -1,28 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <Nullable>enable</Nullable>
+        <LangVersion>default</LangVersion>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
+        <PackageReference Include="MSTest.TestAdapter" Version="3.1.1"/>
+        <PackageReference Include="MSTest.TestFramework" Version="3.1.1"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Storage\Storage.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Storage\Storage.csproj"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Update="Assets\supabase-csharp.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+    <ItemGroup>
+        <None Update="Assets\supabase-csharp.png">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature

## What is the current behavior?



## What is the new behavior?

- avoid duplicate Content-Type headers in upload requests
- apply metadata, headers, and cacheControl dedupe to UploadToSignedUrl
- preserve sortBy defaults when list() receives partial sortBy

## Additional context
https://github.com/supabase-community/supabase-csharp/issues/250
https://github.com/supabase-community/supabase-csharp/issues/252
https://github.com/supabase-community/supabase-csharp/issues/266
