### PR TITLE
fix: lower Newtonsoft.Json minimum version to 13.0.2

### DIFF
--- a/Storage/Storage.csproj
+++ b/Storage/Storage.csproj
@@ -41,7 +41,7 @@
 
     <ItemGroup>
         <PackageReference Include="BirdMessenger" Version="3.1.4" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
         <PackageReference Include="MimeMapping" Version="3.0.1" />
         <PackageReference Include="Supabase.Core" Version="1.0.0" />
     </ItemGroup>


### PR DESCRIPTION
## Problem

Unity 6 LTS ships Newtonsoft.Json 13.0.2 as a built-in managed package that cannot be upgraded independently. The current constraint (`>= 13.0.3`) is unsatisfiable on Unity 6, causing NuGet restore to fail at install time before any user code runs.

Related: supabase-community/supabase-csharp#198

## Change

Lower the Newtonsoft.Json minimum version from 13.0.3 to 13.0.2.

## Why this is safe

13.0.2 and 13.0.3 are consecutive patch releases with no API or behavioural differences. This change widens the accepted range — consumers on 13.0.3 or higher are unaffected, as NuGet treats the declared version as a floor, not a pin.

## Test plan

- [ ] `dotnet restore` succeeds
- [ ] Existing test suite passes