### PR TITLE
feat(): put cache nonce as parameter on some route

### DIFF
--- a/Storage/DownloadOptions.cs
+++ b/Storage/DownloadOptions.cs
@@ -15,5 +15,10 @@ namespace Supabase.Storage
         ///     <p>When field is empty, the original file name will be used. Use <see cref="UseOriginalFileName"/> for quick initialized with original file names.</p>
         /// </summary>
         public string? FileName { get; set; }
+        
+        /// <summary>
+        /// Append a cache nonce parameter to the URL to invalidate the cache
+        /// </summary>
+        public string? CacheNonce { get; set; }
     }
 }

--- a/Storage/Extensions/DownloadOptionsExtension.cs
+++ b/Storage/Extensions/DownloadOptionsExtension.cs
@@ -14,12 +14,16 @@ namespace Supabase.Storage.Extensions
         {
             var query = HttpUtility.ParseQueryString(string.Empty);
 
-            if (download.FileName == null)
+            if (download.FileName != null)
             {
-                return query;
+                query.Add("download", string.IsNullOrEmpty(download.FileName) ? "true" : download.FileName);
             }
             
-            query.Add("download", string.IsNullOrEmpty(download.FileName) ? "true" : download.FileName);
+            
+            if (download.CacheNonce != null)
+            {
+                query.Add("cacheNonce", download.CacheNonce);
+            }
 
             return query;
         }

--- a/Storage/Interfaces/IStorageFileApi.cs
+++ b/Storage/Interfaces/IStorageFileApi.cs
@@ -20,38 +20,43 @@ namespace Supabase.Storage.Interfaces
             int expiresIn,
             DownloadOptions? options = null
         );
-        Task<byte[]> Download(string supabasePath, EventHandler<float>? onProgress = null, CancellationToken cancellationToken = default);
+        Task<byte[]> Download(string supabasePath, EventHandler<float>? onProgress = null, CancellationToken cancellationToken = default, string? cacheNonce = null);
         Task<byte[]> Download(
             string supabasePath,
             TransformOptions? transformOptions = null,
             EventHandler<float>? onProgress = null,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            string? cacheNonce = null
         );
         Task<string> Download(
             string supabasePath,
             string localPath,
             EventHandler<float>? onProgress = null,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            string? cacheNonce = null
         );
         Task<string> Download(
             string supabasePath,
             string localPath,
             TransformOptions? transformOptions = null,
             EventHandler<float>? onProgress = null,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            string? cacheNonce = null
         );
         Task<byte[]> DownloadPublicFile(
             string supabasePath,
             TransformOptions? transformOptions = null,
             EventHandler<float>? onProgress = null,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            string? cacheNonce = null
         );
         Task<string> DownloadPublicFile(
             string supabasePath,
             string localPath,
             TransformOptions? transformOptions = null,
             EventHandler<float>? onProgress = null,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            string? cacheNonce = null
         );
         string GetPublicUrl(
             string path,

--- a/Storage/StorageFileApi.cs
+++ b/Storage/StorageFileApi.cs
@@ -515,20 +515,22 @@ namespace Supabase.Storage
         /// <param name="transformOptions"></param>
         /// <param name="onProgress"></param>
         /// <param name="cancellationToken"></param>
+        /// <param name="cacheNonce"></param>
         /// <returns></returns>
         public Task<string> Download(
             string supabasePath,
             string localPath,
             TransformOptions? transformOptions = null,
             EventHandler<float>? onProgress = null,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            string? cacheNonce = null
         )
         {
             var url =
                 transformOptions != null
                     ? $"{Url}/render/image/authenticated/{GetFinalPath(supabasePath)}"
                     : $"{Url}/object/{GetFinalPath(supabasePath)}";
-            return DownloadFile(url, localPath, transformOptions, onProgress, cancellationToken);
+            return DownloadFile(url, localPath, transformOptions, onProgress, cancellationToken, cacheNonce);
         }
 
         /// <summary>
@@ -538,13 +540,15 @@ namespace Supabase.Storage
         /// <param name="localPath"></param>
         /// <param name="onProgress"></param>
         /// <param name="cancellationToken"></param>
+        /// <param name="cacheNonce"></param>
         /// <returns></returns>
         public Task<string> Download(
             string supabasePath,
             string localPath,
             EventHandler<float>? onProgress = null,
-            CancellationToken cancellationToken = default
-        ) => Download(supabasePath, localPath, null, onProgress: onProgress, cancellationToken);
+            CancellationToken cancellationToken = default,
+            string? cacheNonce = null
+        ) => Download(supabasePath, localPath, null, onProgress: onProgress, cancellationToken, cacheNonce);
 
         /// <summary>
         /// Downloads a byte array from a private bucket to be used programmatically. For public buckets <see cref="DownloadPublicFile(string, TransformOptions?, EventHandler{float}?)"/>
@@ -553,16 +557,18 @@ namespace Supabase.Storage
         /// <param name="transformOptions"></param>
         /// <param name="onProgress"></param>
         /// <param name="cancellationToken"></param>
+        /// <param name="cacheNonce"></param>
         /// <returns></returns>
         public Task<byte[]> Download(
             string supabasePath,
             TransformOptions? transformOptions = null,
             EventHandler<float>? onProgress = null,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            string? cacheNonce = null
         )
         {
             var url = $"{Url}/object/{GetFinalPath(supabasePath)}";
-            return DownloadBytes(url, transformOptions, onProgress, cancellationToken);
+            return DownloadBytes(url, transformOptions, onProgress, cancellationToken, cacheNonce);
         }
 
         /// <summary>
@@ -571,9 +577,10 @@ namespace Supabase.Storage
         /// <param name="supabasePath"></param>
         /// <param name="onProgress"></param>
         /// <param name="cancellationToken"></param>
+        /// <param name="cacheNonce"></param>
         /// <returns></returns>
-        public Task<byte[]> Download(string supabasePath, EventHandler<float>? onProgress = null, CancellationToken cancellationToken = default) =>
-            Download(supabasePath, transformOptions: null, onProgress: onProgress, cancellationToken);
+        public Task<byte[]> Download(string supabasePath, EventHandler<float>? onProgress = null, CancellationToken cancellationToken = default, string? cacheNonce = null) =>
+            Download(supabasePath, transformOptions: null, onProgress: onProgress, cancellationToken, cacheNonce);
 
         /// <summary>
         /// Downloads a public file to the filesystem. This method DOES NOT VERIFY that the file is actually public.
@@ -583,17 +590,19 @@ namespace Supabase.Storage
         /// <param name="transformOptions"></param>
         /// <param name="onProgress"></param>
         /// <param name="cancellationToken"></param>
+        /// <param name="cacheNonce"></param>
         /// <returns></returns>
         public Task<string> DownloadPublicFile(
             string supabasePath,
             string localPath,
             TransformOptions? transformOptions = null,
             EventHandler<float>? onProgress = null,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            string? cacheNonce = null
         )
         {
             var url = GetPublicUrl(supabasePath, transformOptions);
-            return DownloadFile(url, localPath, transformOptions, onProgress, cancellationToken);
+            return DownloadFile(url, localPath, transformOptions, onProgress, cancellationToken, cacheNonce);
         }
 
         /// <summary>
@@ -603,16 +612,18 @@ namespace Supabase.Storage
         /// <param name="transformOptions"></param>
         /// <param name="onProgress"></param>
         /// <param name="cancellationToken"></param>
+        /// <param name="cacheNonce"></param>
         /// <returns></returns>
         public Task<byte[]> DownloadPublicFile(
             string supabasePath,
             TransformOptions? transformOptions = null,
             EventHandler<float>? onProgress = null,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            string? cacheNonce = null
         )
         {
             var url = GetPublicUrl(supabasePath, transformOptions);
-            return DownloadBytes(url, transformOptions, onProgress, cancellationToken);
+            return DownloadBytes(url, transformOptions, onProgress, cancellationToken, cacheNonce);
         }
 
         /// <summary>
@@ -859,14 +870,21 @@ namespace Supabase.Storage
             string localPath,
             TransformOptions? transformOptions = null,
             EventHandler<float>? onProgress = null,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            string? cacheNonce = null
         )
         {
+            var query = HttpUtility.ParseQueryString(string.Empty);
             var builder = new UriBuilder(url);
             var progress = new Progress<float>();
 
             if (transformOptions != null)
-                builder.Query = transformOptions.ToQueryCollection().ToString();
+                query.Add(transformOptions.ToQueryCollection());
+
+            if (cacheNonce != null)
+                query.Add("cacheNonce", cacheNonce);
+            
+            builder.Query = query.ToString();
 
             if (onProgress != null)
                 progress.ProgressChanged += onProgress;
@@ -893,14 +911,21 @@ namespace Supabase.Storage
             string url,
             TransformOptions? transformOptions = null,
             EventHandler<float>? onProgress = null,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            string? cacheNonce = null
         )
         {
+            var query = HttpUtility.ParseQueryString(string.Empty);
             var builder = new UriBuilder(url);
             var progress = new Progress<float>();
 
             if (transformOptions != null)
-                builder.Query = transformOptions.ToQueryCollection().ToString();
+                query.Add(transformOptions.ToQueryCollection());
+
+            if (cacheNonce != null)
+                query.Add("cacheNonce", cacheNonce);
+
+            builder.Query = query.ToString();
 
             if (onProgress != null)
                 progress.ProgressChanged += onProgress;

--- a/StorageTests/Files/StorageFileApiContractTests.cs
+++ b/StorageTests/Files/StorageFileApiContractTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Linq;
 using System.Collections.Generic;
 using System.Text;
@@ -13,6 +14,7 @@ using WireMock;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
+using FileOptions = Supabase.Storage.FileOptions;
 
 namespace StorageTests.Files;
 
@@ -287,6 +289,35 @@ public class StorageFileApiContractTests
         {
             bytes.Should().Equal(payload);
             this.SingleRequest().Path.Should().Be($"/storage/v1/object/{Bucket}/a.bin");
+        }
+    }
+
+    [TestMethod]
+    public async Task Download_ShouldSendTheCacheNonceInTheQuery_GivenACacheNonce()
+    {
+        this.server.Given(Request.Create().WithPath($"/storage/v1/object/{Bucket}/a.bin").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(Encoding.UTF8.GetBytes("file-bytes")));
+        await this.client.From(Bucket).Download("a.bin", (EventHandler<float>?) null, cacheNonce: "nonce-123");
+        this.SingleRequest().Query!.Should().ContainKey("cacheNonce")
+            .WhoseValue.Should().Contain("nonce-123", "the nonce must ride the request so the CDN cache is bypassed");
+    }
+
+    [TestMethod]
+    public async Task Download_ShouldSendTheCacheNonceInTheQuery_GivenACacheNonceAndLocalPath()
+    {
+        this.server.Given(Request.Create().WithPath($"/storage/v1/object/{Bucket}/a.bin").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(Encoding.UTF8.GetBytes("file-bytes")));
+        var localPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.bin");
+        try
+        {
+            await this.client.From(Bucket).Download("a.bin", localPath, (EventHandler<float>?) null, cacheNonce: "nonce-123");
+            this.SingleRequest().Query!.Should().ContainKey("cacheNonce")
+                .WhoseValue.Should().Contain("nonce-123", "the to-disk path must carry the nonce just as the byte path does");
+        }
+        finally
+        {
+            if (File.Exists(localPath))
+                File.Delete(localPath);
         }
     }
 

--- a/StorageTests/Files/StorageFileTests.cs
+++ b/StorageTests/Files/StorageFileTests.cs
@@ -193,6 +193,20 @@ public class StorageFileTests
     }
 
     [TestMethod]
+    public async Task Download_ShouldWriteFileToDisk_GivenCacheNonce()
+    {
+        var progressed = new TaskCompletionSource<bool>();
+        var name = $"{Guid.NewGuid()}.png";
+        var imagePath = Path.Combine(BasePath(), "Assets", "supabase-csharp.png");
+        await this.bucket.Upload(imagePath, name);
+        var downloadPath = Path.Combine(BasePath(), name);
+        await this.bucket.Download(name, downloadPath, (_, _) => progressed.TrySetResult(true), CancellationToken.None, DateTime.UtcNow.ToShortDateString());
+        (await progressed.Task).Should().BeTrue();
+        File.Exists(downloadPath).Should().BeTrue();
+        await this.bucket.Remove(new List<string> { name });
+    }
+
+    [TestMethod]
     public async Task Download_ShouldCancelAndLeaveNoFile_GivenCancelledToken()
     {
         using var cts = new CancellationTokenSource();
@@ -282,6 +296,16 @@ public class StorageFileTests
     }
 
     [TestMethod]
+    public async Task GetPublicUrl_ShouldAppendTheDownloadName_GivenFullFilledDownloadOptions()
+    {
+        var name = $"{Guid.NewGuid()}.bin";
+        await this.bucket.Upload(new byte[] { 0x0, 0x1 }, name);
+        var url = this.bucket.GetPublicUrl(name, null, new DownloadOptions { FileName = "custom-file.png", CacheNonce = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ") });
+        url.Should().Contain("download=custom-file.png&cacheNonce");
+        await this.bucket.Remove(new List<string> { name });
+    }
+
+    [TestMethod]
     public async Task GetPublicUrl_ShouldAppendDownloadTrue_GivenTransformAndOriginalName()
     {
         var name = $"{Guid.NewGuid()}.bin";
@@ -320,6 +344,17 @@ public class StorageFileTests
         var url = await this.bucket.CreateSignedUrl(name, 3600, null, new DownloadOptions { FileName = "custom-file.png" });
         Uri.IsWellFormedUriString(url, UriKind.Absolute).Should().BeTrue();
         url.Should().Contain("download=custom-file.png");
+        await this.bucket.Remove(new List<string> { name });
+    }
+
+    [TestMethod]
+    public async Task CreateSignedUrl_ShouldAppendTheDownloadName_GivenFullFilledDownloadOptions()
+    {
+        var name = $"{Guid.NewGuid()}.bin";
+        await this.bucket.Upload(new byte[] { 0x0, 0x1 }, name);
+        var url = await this.bucket.CreateSignedUrl(name, 3600, null, new DownloadOptions { FileName = "custom-file.png", CacheNonce = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")});
+        Uri.IsWellFormedUriString(url, UriKind.Absolute).Should().BeTrue();
+        url.Should().Contain("download=custom-file.png&cacheNonce");
         await this.bucket.Remove(new List<string> { name });
     }
 

--- a/StorageTests/Files/StorageFileTests.cs
+++ b/StorageTests/Files/StorageFileTests.cs
@@ -193,20 +193,6 @@ public class StorageFileTests
     }
 
     [TestMethod]
-    public async Task Download_ShouldWriteFileToDisk_GivenCacheNonce()
-    {
-        var progressed = new TaskCompletionSource<bool>();
-        var name = $"{Guid.NewGuid()}.png";
-        var imagePath = Path.Combine(BasePath(), "Assets", "supabase-csharp.png");
-        await this.bucket.Upload(imagePath, name);
-        var downloadPath = Path.Combine(BasePath(), name);
-        await this.bucket.Download(name, downloadPath, (_, _) => progressed.TrySetResult(true), CancellationToken.None, DateTime.UtcNow.ToShortDateString());
-        (await progressed.Task).Should().BeTrue();
-        File.Exists(downloadPath).Should().BeTrue();
-        await this.bucket.Remove(new List<string> { name });
-    }
-
-    [TestMethod]
     public async Task Download_ShouldCancelAndLeaveNoFile_GivenCancelledToken()
     {
         using var cts = new CancellationTokenSource();
@@ -296,16 +282,6 @@ public class StorageFileTests
     }
 
     [TestMethod]
-    public async Task GetPublicUrl_ShouldAppendTheDownloadName_GivenFullFilledDownloadOptions()
-    {
-        var name = $"{Guid.NewGuid()}.bin";
-        await this.bucket.Upload(new byte[] { 0x0, 0x1 }, name);
-        var url = this.bucket.GetPublicUrl(name, null, new DownloadOptions { FileName = "custom-file.png", CacheNonce = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ") });
-        url.Should().Contain("download=custom-file.png&cacheNonce");
-        await this.bucket.Remove(new List<string> { name });
-    }
-
-    [TestMethod]
     public async Task GetPublicUrl_ShouldAppendDownloadTrue_GivenTransformAndOriginalName()
     {
         var name = $"{Guid.NewGuid()}.bin";
@@ -344,17 +320,6 @@ public class StorageFileTests
         var url = await this.bucket.CreateSignedUrl(name, 3600, null, new DownloadOptions { FileName = "custom-file.png" });
         Uri.IsWellFormedUriString(url, UriKind.Absolute).Should().BeTrue();
         url.Should().Contain("download=custom-file.png");
-        await this.bucket.Remove(new List<string> { name });
-    }
-
-    [TestMethod]
-    public async Task CreateSignedUrl_ShouldAppendTheDownloadName_GivenFullFilledDownloadOptions()
-    {
-        var name = $"{Guid.NewGuid()}.bin";
-        await this.bucket.Upload(new byte[] { 0x0, 0x1 }, name);
-        var url = await this.bucket.CreateSignedUrl(name, 3600, null, new DownloadOptions { FileName = "custom-file.png", CacheNonce = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")});
-        Uri.IsWellFormedUriString(url, UriKind.Absolute).Should().BeTrue();
-        url.Should().Contain("download=custom-file.png&cacheNonce");
         await this.bucket.Remove(new List<string> { name });
     }
 

--- a/StorageTests/Options/DownloadOptionsExtensionTests.cs
+++ b/StorageTests/Options/DownloadOptionsExtensionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Supabase.Storage;
@@ -33,5 +34,12 @@ public class DownloadOptionsExtensionTests
     {
         var query = new DownloadOptions { FileName = "custom-file.png" }.ToQueryCollection();
         query["download"].Should().Be("custom-file.png");
+    }
+
+    [TestMethod]
+    public void ToQueryCollection_ShouldEmitTheCacheNonce_GivenAName()
+    {
+        var query = new DownloadOptions { CacheNonce = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ") }.ToQueryCollection();
+        query["cacheNonce"].Should().Be(DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"));
     }
 }

--- a/StorageTests/Options/DownloadOptionsExtensionTests.cs
+++ b/StorageTests/Options/DownloadOptionsExtensionTests.cs
@@ -1,4 +1,3 @@
-using System;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Supabase.Storage;
@@ -37,9 +36,9 @@ public class DownloadOptionsExtensionTests
     }
 
     [TestMethod]
-    public void ToQueryCollection_ShouldEmitTheCacheNonce_GivenAName()
+    public void ToQueryCollection_ShouldEmitTheCacheNonce_GivenACacheNonce()
     {
-        var query = new DownloadOptions { CacheNonce = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ") }.ToQueryCollection();
-        query["cacheNonce"].Should().Be(DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"));
+        var query = new DownloadOptions { CacheNonce = "nonce-123" }.ToQueryCollection();
+        query["cacheNonce"].Should().Be("nonce-123");
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

- implement cache nonce on download, create and get urls, related to
https://github.com/supabase-community/supabase-csharp/issues/246

## Additional context

related https://github.com/supabase-community/supabase-csharp/issues/246
